### PR TITLE
prevent node to be put in garbage when builded from cache

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -88,12 +88,12 @@ const SearchIndex = new GraphQLScalarType({
 exports.sourceNodes = async ({ getNodes, boundActionCreators }) => {
     const {
         touchNode,
-    } = boundActionCreators
+    } = boundActionCreators;
 
     const existingNodes = getNodes().filter(
         n => n.internal.owner === `@andrew-codes/gatsby-plugin-elasticlunr-search`
-    )
-    existingNodes.forEach(n => touchNode(n.id))
+    );
+    existingNodes.forEach(n => touchNode(n.id));
 };
 
 exports.onCreateNode = ({node, boundActionCreators, getNode}, {

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -85,6 +85,17 @@ const SearchIndex = new GraphQLScalarType({
     },
 });
 
+exports.sourceNodes = async ({ getNodes, boundActionCreators }) => {
+    const {
+        touchNode,
+    } = boundActionCreators
+
+    const existingNodes = getNodes().filter(
+        n => n.internal.owner === `@andrew-codes/gatsby-plugin-elasticlunr-search`
+    )
+    existingNodes.forEach(n => touchNode(n.id))
+};
+
 exports.onCreateNode = ({node, boundActionCreators, getNode}, {
     resolvers,
 }) => {


### PR DESCRIPTION
By touching the node it will prevent the node to fail the stale check.

https://www.gatsbyjs.org/docs/bound-action-creators/#touchNode